### PR TITLE
Fix highlighting in string escapes for emacs tree-sitter-mode

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,14 +1,14 @@
 (comment) @comment
 
 [
-  "if" 
+  "if"
   "then"
   "else"
   "let"
   "inherit"
   "in"
   "rec"
-  "with" 
+  "with"
   "assert"
   "or"
 ] @keyword
@@ -22,26 +22,9 @@
  (#is-not? local))
 
 [
-  (string_expression)
-  (indented_string_expression)
-] @string
-
-[
-  (path_expression)
-  (hpath_expression)
-  (spath_expression)
-] @string.special.path
-
-(uri_expression) @string.special.uri
-
-[
   (integer_expression)
   (float_expression)
 ] @number
-
-(interpolation
-  "${" @punctuation.special
-  "}" @punctuation.special) @embedded
 
 (escape_sequence) @escape
 (dollar_escape) @escape
@@ -96,3 +79,21 @@
 ] @punctuation.bracket
 
 (identifier) @variable
+
+[
+  (string_expression)
+  (indented_string_expression)
+] @string
+
+[
+  (path_expression)
+  (hpath_expression)
+  (spath_expression)
+] @string.special.path
+
+(uri_expression) @string.special.uri
+
+(interpolation
+  "${" @punctuation.special
+  (_) @embedded
+  "}" @punctuation.special)

--- a/test/highlight/basic.nix
+++ b/test/highlight/basic.nix
@@ -49,7 +49,7 @@
       #      ^ string
       #       ^ punctuation.special
       #          ^ variable
-      #              ^ punctuation.special
+      #              ^ punctuation.bracket
       #               ^ string
       #                   ^ variable
       #                          ^ string


### PR DESCRIPTION
### Reason
`tree-sitter-mode` seems a bit picky about the order in which expressions are listed in `highlights.scm` and won't highlight expressions inside string escapes correctly without this change. *Note:* I haven't tried the change with any other editor.

### Before and after
![before](https://github.com/nix-community/tree-sitter-nix/assets/63433/9add239b-69db-404a-9210-c3f9012cf73d)
![after](https://github.com/nix-community/tree-sitter-nix/assets/63433/2ef81b5f-3d7f-41a8-8bef-394b5a56be75)
