### PR TITLE
feat: add `testScript` python injection

### DIFF
--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -37,3 +37,13 @@
   (#match? @_path "^text$")
   (#set! injection.language "bash")
   (#set! injection.combined))
+
+((binding
+  attrpath: (attrpath (identifier) @_path)
+    expression: [
+      (indented_string_expression (string_fragment) @injection.content)
+      (function_expression body: (indented_string_expression (string_fragment) @injection.content))
+    ])
+  (#eq? @_path "testScript")
+  (#set! injection.language "python")
+  (#set! injection.combined))


### PR DESCRIPTION
Matches against both of:
```nix
{
  testScript = ''
    import numpy as np
    assert str(np.zeros(4) == "array([0., 0., 0., 0.])") 
  '';
  testScript = {...}: ''
    import numpy as np
    assert str(np.zeros(4) == "array([0., 0., 0., 0.])") 
  '';
}
```

Closes #54 