### PR TITLE
Bumps tree-sitter Rust dependency to 0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,4 +85,5 @@ version = "0.0.1"
 dependencies = [
  "cc",
  "tree-sitter",
+ "tree-sitter-language",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
+tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
 tree-sitter = "0.23"
 
 [build-dependencies]

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -4,10 +4,22 @@
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
-//! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(&tree_sitter_nix::language()).expect("Error loading nix grammar");
+//! use tree_sitter::Parser;
+//!
+//! let code = r#"
+//! let
+//!   b = a + 1;
+//!   a = 1;
+//! in
+//! a + b
+//! "#;
+//! let mut parser = Parser::new();
+//! let language = tree_sitter_nix::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading nix parser");
 //! let tree = parser.parse(code, None).unwrap();
+//! assert!(!tree.root_node().has_error());
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
@@ -15,18 +27,14 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_nix() -> Language;
+    fn tree_sitter_nix() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_nix() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_nix) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -35,9 +43,16 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 // Uncomment these to include any queries that this grammar contains
 
+/// The syntax highlighting query for this language.
 pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+
+// The injections query for this language.
 // pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+
+// The locals tagging query for this language.
 // pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+
+/// The symbol tagging query for this language.
 // pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
@@ -46,7 +61,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(&super::language())
-            .expect("Error loading nix language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading nix parser");
     }
 }


### PR DESCRIPTION


This PR updates the tree-sitter version to 0.23 and makes corresponding changes to the rust bindings to make them uniform with current most up to date grammars for languages like C and C++.

The new lib.rs attempts to reproduce the behavior of @amaanq's corresponding changes elsewhere.